### PR TITLE
Make KMS keys not a required variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ See [example](examples/complete).
 | chatbot\_role\_allow\_support\_access | Allow users to interact with AWS support from Slack. | `bool` | `false` | no |
 | chatbot\_role\_permissions\_boundary\_policy\_arn | IAM policy document to use as permissions boundary in the Chatbot IAM role.<br>Useful in combination with read only access to limit resources that can<br>be accessed from Slack. | `string` | `""` | no |
 | enabled | Whether to create resources or not. | `bool` | `true` | no |
-| kms\_key\_id | KMS key id to use with SNS topic. | `string` | n/a | yes |
+| kms\_key\_id | KMS key id to use with SNS topic. | `string` | "" | no |
 | log\_level | Log level AWS Chatbot should use. Possible values are ERROR, INFO, NONE. | `string` | `"INFO"` | no |
 | slack\_channel\_id | ID of the Slack channel configure with AWS Chatbot.<br>Can be determined by right-clicking the channel in Slack and choosing<br>copy link. The channel ID is the last part of the copied URL. | `string` | n/a | yes |
 | slack\_workspace\_id | ID of the Slack workspace containing the channel to use with AWS Chatbot.<br>Can be found in the AWS Chatbot console. | `string` | n/a | yes |

--- a/variables.tf
+++ b/variables.tf
@@ -12,6 +12,7 @@ variable "sns_topic_name" {
 variable "kms_key_id" {
   type = string
   description = "KMS key id to use with SNS topic."
+  default = ""
 }
 
 variable "chatbot_config_name" {


### PR DESCRIPTION
KMS keys aren't required for SNS topics, and in fact if you give this module an alias to one (eg `alias/aws/sns`) then Chatbot will fail to decrypt the SNS message and not send a message to Slack, so I've made it optional.