### PR TITLE
add codestar-notifications.amazonaws.com for notifying CodePipeline E…

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -44,6 +44,7 @@ data "aws_iam_policy_document" "sns_chatbot" {
       type = "Service"
       identifiers = [
         # FIXME: "billingconsole.amazonaws.com",
+        "codestar-notifications.amazonaws.com",
         "budgets.amazonaws.com",
         "cloudformation.amazonaws.com",
         "cloudwatch.amazonaws.com",


### PR DESCRIPTION
add codestar-notifications.amazonaws.com for notifying CodePipeline Events.

This allows the codestar-notifications service i.e responsible for notifying the status of code pipeline stages to post to SNS topic for the slack chatbot