### PR TITLE
Cleanup providers

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,11 +3,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
-      version = ">= 2.0"
-    }
-    template = {
-      source = "hashicorp/template"
-      version = ">= 2.0"
+      version = ">= 3.0"
     }
   }
 }


### PR DESCRIPTION
This removes hashicorp/template, which is unused and explodes violently on Apple M1s.

I also updated AWS provider from 2.0 to 3.0 just because 2.0 is ancient at this point.